### PR TITLE
Add dualread support to core-v-xif

### DIFF
--- a/rtl/cv32e40px_cs_registers.sv
+++ b/rtl/cv32e40px_cs_registers.sv
@@ -1455,7 +1455,7 @@ module cv32e40px_cs_registers
       // minstret is located at index 2
       // Programable HPM counters start at index 3
       if ((cnt_gidx == 1) || (cnt_gidx >= (NUM_MHPMCOUNTERS + 3))) begin : gen_non_implemented
-        assign mhpmcounter_q[cnt_gidx] = 'b0;
+        always_ff @(posedge clk) mhpmcounter_q[cnt_gidx] <= 'b0;
       end else begin : gen_implemented
         always_ff @(posedge clk, negedge rst_n)
           if (!rst_n) begin
@@ -1483,10 +1483,10 @@ module cv32e40px_cs_registers
     for (evt_gidx = 0; evt_gidx < 32; evt_gidx++) begin : gen_mhpmevent
       // programable HPM events start at index3
       if ((evt_gidx < 3) || (evt_gidx >= (NUM_MHPMCOUNTERS + 3))) begin : gen_non_implemented
-        assign mhpmevent_q[evt_gidx] = 'b0;
+        always_ff @(posedge clk) mhpmevent_q[evt_gidx] <= 'b0;
       end else begin : gen_implemented
         if (NUM_HPM_EVENTS < 32) begin : gen_tie_off
-          assign mhpmevent_q[evt_gidx][31:NUM_HPM_EVENTS] = 'b0;
+          always_ff @(posedge clk) mhpmevent_q[evt_gidx][31:NUM_HPM_EVENTS] <= 'b0;
         end
         always_ff @(posedge clk, negedge rst_n)
           if (!rst_n) mhpmevent_q[evt_gidx][NUM_HPM_EVENTS-1:0] <= 'b0;
@@ -1504,7 +1504,7 @@ module cv32e40px_cs_registers
           (en_gidx == 1) ||
           (en_gidx >= (NUM_MHPMCOUNTERS+3) ) )
         begin : gen_non_implemented
-        assign mcounteren_q[en_gidx] = 'b0;
+        always_ff @(posedge clk) mcounteren_q[en_gidx] <= 'b0;
       end else begin : gen_implemented
         always_ff @(posedge clk, negedge rst_n)
           if (!rst_n) mcounteren_q[en_gidx] <= 'b0;  // default disable
@@ -1519,7 +1519,7 @@ module cv32e40px_cs_registers
   generate
     for (inh_gidx = 0; inh_gidx < 32; inh_gidx++) begin : gen_mcountinhibit
       if ((inh_gidx == 1) || (inh_gidx >= (NUM_MHPMCOUNTERS + 3))) begin : gen_non_implemented
-        assign mcountinhibit_q[inh_gidx] = 'b0;
+        always_ff @(posedge clk) mcountinhibit_q[inh_gidx] <= 'b0;
       end else begin : gen_implemented
         always_ff @(posedge clk, negedge rst_n)
           if (!rst_n) mcountinhibit_q[inh_gidx] <= 'b1;  // default disable

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -1192,12 +1192,10 @@ module cv32e40px_id_stage
             end else begin
               x_issue_req_o.rs[i + 3 * j] = regfile_data_rc_id[j];
             end
-            if (j == 0) begin
-              if (x_ex_fwd[i]) begin
-                x_issue_req_o.rs[i] = result_fw_to_x_i;
-              end else if (x_wb_fwd[i]) begin
-                x_issue_req_o.rs[i] = regfile_wdata_wb_i;
-              end
+            if (x_ex_fwd[i]) begin
+              x_issue_req_o.rs[i + 3 * j] = result_fw_to_x_i;
+            end else if (x_wb_fwd[i]) begin
+              x_issue_req_o.rs[i + 3 * j] = regfile_wdata_wb_i;
             end
           end
         end

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -1192,10 +1192,12 @@ module cv32e40px_id_stage
             end else begin
               x_issue_req_o.rs[i + 3 * j] = regfile_data_rc_id[j];
             end
-            if (x_ex_fwd[i]) begin
-              x_issue_req_o.rs[i] = result_fw_to_x_i;
-            end else if (x_wb_fwd[i]) begin
-              x_issue_req_o.rs[i] = regfile_wdata_wb_i;
+            if (j == 0) begin
+              if (x_ex_fwd[i]) begin
+                x_issue_req_o.rs[i] = result_fw_to_x_i;
+              end else if (x_wb_fwd[i]) begin
+                x_issue_req_o.rs[i] = regfile_wdata_wb_i;
+              end
             end
           end
         end

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -302,7 +302,7 @@ module cv32e40px_id_stage
   localparam REG_D_MSB = 11;
   localparam REG_D_LSB = 7;
 
-  localparam REGFILE_NUM_READ_PORTS = (COREV_X_IF & X_DUALREAD) ? 2 : 1; 
+  localparam REGFILE_NUM_READ_PORTS = (COREV_X_IF & X_DUALREAD) ? 2 : 1;
 
   logic [31:0] instr;
 
@@ -1037,44 +1037,44 @@ module cv32e40px_id_stage
   // |_| \_\_____\____|___|____/ |_| |_____|_| \_\____/  //
   //                                                     //
   /////////////////////////////////////////////////////////
-  
-      cv32e40px_register_file #(
-        .ADDR_WIDTH(6),
-        .DATA_WIDTH(32),
-        .FPU       (FPU),
-        .ZFINX     (ZFINX),
-        .COREV_X_IF(COREV_X_IF),
-        .X_DUALREAD(X_DUALREAD)
-      ) register_file_i (
-        .clk  (clk),
-        .rst_n(rst_n),
 
-        .scan_cg_en_i(scan_cg_en_i),
+  cv32e40px_register_file #(
+      .ADDR_WIDTH(6),
+      .DATA_WIDTH(32),
+      .FPU       (FPU),
+      .ZFINX     (ZFINX),
+      .COREV_X_IF(COREV_X_IF),
+      .X_DUALREAD(X_DUALREAD)
+  ) register_file_i (
+      .clk  (clk),
+      .rst_n(rst_n),
 
-        .dualread_i(x_issue_resp_i.dualread),
+      .scan_cg_en_i(scan_cg_en_i),
 
-        // Read port a
-        .raddr_a_i(regfile_addr_ra_id),
-        .rdata_a_o(regfile_data_ra_id),
+      .dualread_i(x_issue_resp_i.dualread),
 
-        // Read port b
-        .raddr_b_i(regfile_addr_rb_id),
-        .rdata_b_o(regfile_data_rb_id),
+      // Read port a
+      .raddr_a_i(regfile_addr_ra_id),
+      .rdata_a_o(regfile_data_ra_id),
 
-        // Read port c
-        .raddr_c_i(regfile_addr_rc_id),
-        .rdata_c_o(regfile_data_rc_id),
+      // Read port b
+      .raddr_b_i(regfile_addr_rb_id),
+      .rdata_b_o(regfile_data_rb_id),
 
-        // Write port a
-        .waddr_a_i(regfile_waddr_wb_i),
-        .wdata_a_i(regfile_wdata_wb_i),
-        .we_a_i   (regfile_we_wb_i),
+      // Read port c
+      .raddr_c_i(regfile_addr_rc_id),
+      .rdata_c_o(regfile_data_rc_id),
 
-        // Write port b
-        .waddr_b_i(regfile_alu_waddr_fw_i),
-        .wdata_b_i(regfile_alu_wdata_fw_i),
-        .we_b_i   (regfile_alu_we_fw_i)
-      );
+      // Write port a
+      .waddr_a_i(regfile_waddr_wb_i),
+      .wdata_a_i(regfile_wdata_wb_i),
+      .we_a_i   (regfile_we_wb_i),
+
+      // Write port b
+      .waddr_b_i(regfile_alu_waddr_fw_i),
+      .wdata_b_i(regfile_alu_wdata_fw_i),
+      .we_b_i   (regfile_alu_we_fw_i)
+  );
 
   logic [1:0] x_mem_data_type_id;
 
@@ -1186,16 +1186,16 @@ module cv32e40px_id_stage
         for (genvar i = 0; i < 3; i++) begin : xif_operand_assignment
           always_comb begin
             if (i == 0) begin
-              x_issue_req_o.rs[i + 3 * j] = regfile_data_ra_id[j];
+              x_issue_req_o.rs[i+3*j] = regfile_data_ra_id[j];
             end else if (i == 1) begin
-              x_issue_req_o.rs[i + 3 * j] = regfile_data_rb_id[j];
+              x_issue_req_o.rs[i+3*j] = regfile_data_rb_id[j];
             end else begin
-              x_issue_req_o.rs[i + 3 * j] = regfile_data_rc_id[j];
+              x_issue_req_o.rs[i+3*j] = regfile_data_rc_id[j];
             end
             if (x_ex_fwd[i]) begin
-              x_issue_req_o.rs[i + 3 * j] = result_fw_to_x_i;
+              x_issue_req_o.rs[i+3*j] = result_fw_to_x_i;
             end else if (x_wb_fwd[i]) begin
-              x_issue_req_o.rs[i + 3 * j] = regfile_wdata_wb_i;
+              x_issue_req_o.rs[i+3*j] = regfile_wdata_wb_i;
             end
           end
         end

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -383,9 +383,9 @@ module cv32e40px_id_stage
   logic [ 5:0] regfile_alu_waddr_id;
   logic regfile_alu_we_id, regfile_alu_we_dec_id;
 
-  logic [REGFILE_NUM_READ_PORTS:0][31:0] regfile_data_ra_id;
-  logic [REGFILE_NUM_READ_PORTS:0][31:0] regfile_data_rb_id;
-  logic [REGFILE_NUM_READ_PORTS:0][31:0] regfile_data_rc_id;
+  logic [REGFILE_NUM_READ_PORTS-1:0][31:0] regfile_data_ra_id;
+  logic [REGFILE_NUM_READ_PORTS-1:0][31:0] regfile_data_rb_id;
+  logic [REGFILE_NUM_READ_PORTS-1:0][31:0] regfile_data_rc_id;
 
   // ALU Control
   logic alu_en;

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -625,7 +625,7 @@ module cv32e40px_id_stage
   //                       |_|                    |___/           //
   //////////////////////////////////////////////////////////////////
   generate
-    if (COREV_X_IF == 0) begin : no_xif_jump_target_mux
+    if (X_DUALREAD == 0) begin : no_dualread_jump_target_mux
       always_comb begin : jump_target_mux
         unique case (ctrl_transfer_target_mux_sel)
           JT_JAL:  jump_target = pc_id_i + imm_uj_type;
@@ -636,7 +636,7 @@ module cv32e40px_id_stage
           default: jump_target = regfile_data_ra_id + imm_i_type;
         endcase
       end
-    end else begin : xif_jump_target_mux
+    end else begin : dualread_jump_target_mux
       always_comb begin : jump_target_mux
         unique case (ctrl_transfer_target_mux_sel)
           JT_JAL:  jump_target = pc_id_i + imm_uj_type;
@@ -683,7 +683,7 @@ module cv32e40px_id_stage
   end
 
   generate
-    if (COREV_X_IF == 0) begin : no_xif_fw_a
+    if (X_DUALREAD == 0) begin : no_dualread_fw_a
       // Operand a forwarding mux
       always_comb begin : operand_a_fw_mux
         case (operand_a_fw_mux_sel)
@@ -694,7 +694,7 @@ module cv32e40px_id_stage
         endcase
         ;  // case (operand_a_fw_mux_sel)
       end
-    end else begin : xif_fw_a
+    end else begin : dualread_fw_a
       // Operand a forwarding mux
       always_comb begin : operand_a_fw_mux
         case (operand_a_fw_mux_sel)
@@ -764,7 +764,7 @@ module cv32e40px_id_stage
 
 
   generate
-    if (COREV_X_IF == 0) begin : no_xif_fw_b
+    if (X_DUALREAD == 0) begin : no_dualread_fw_b
       // Operand b forwarding mux
       always_comb begin : operand_b_fw_mux
         case (operand_b_fw_mux_sel)
@@ -775,7 +775,7 @@ module cv32e40px_id_stage
         endcase
         ;  // case (operand_b_fw_mux_sel)
       end
-    end else begin : xif_fw_b
+    end else begin : dualread_fw_b
       // Operand b forwarding mux
       always_comb begin : operand_b_fw_mux
         case (operand_b_fw_mux_sel)
@@ -824,7 +824,7 @@ module cv32e40px_id_stage
 
 
   generate
-    if (COREV_X_IF == 0) begin : no_xif_fw_c
+    if (X_DUALREAD == 0) begin : no_dualread_fw_c
       // Operand c forwarding mux
       always_comb begin : operand_c_fw_mux
         case (operand_c_fw_mux_sel)
@@ -835,7 +835,7 @@ module cv32e40px_id_stage
         endcase
         ;  // case (operand_c_fw_mux_sel)
       end
-    end else begin : xif_fw_c
+    end else begin : dualread_fw_c
       // Operand c forwarding mux
       always_comb begin : operand_c_fw_mux
         case (operand_c_fw_mux_sel)

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -302,7 +302,8 @@ module cv32e40px_id_stage
   localparam REG_D_MSB = 11;
   localparam REG_D_LSB = 7;
 
-  localparam REGFILE_NUM_READ_PORTS = (COREV_X_IF & X_DUALREAD) ? 2 : 1;
+
+  localparam REGFILE_NUM_READ_PORTS = ((COREV_X_IF == 1) & (X_DUALREAD == 1)) ? 2 : 1;
 
   logic [31:0] instr;
 

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -626,28 +626,15 @@ module cv32e40px_id_stage
   //                       |_|                    |___/           //
   //////////////////////////////////////////////////////////////////
   generate
-    if (X_DUALREAD == 0) begin : no_dualread_jump_target_mux
-      always_comb begin : jump_target_mux
-        unique case (ctrl_transfer_target_mux_sel)
-          JT_JAL:  jump_target = pc_id_i + imm_uj_type;
-          JT_COND: jump_target = pc_id_i + imm_sb_type;
+    always_comb begin : jump_target_mux
+      unique case (ctrl_transfer_target_mux_sel)
+        JT_JAL:  jump_target = pc_id_i + imm_uj_type;
+        JT_COND: jump_target = pc_id_i + imm_sb_type;
 
-          // JALR: Cannot forward RS1, since the path is too long
-          JT_JALR: jump_target = regfile_data_ra_id + imm_i_type;
-          default: jump_target = regfile_data_ra_id + imm_i_type;
-        endcase
-      end
-    end else begin : dualread_jump_target_mux
-      always_comb begin : jump_target_mux
-        unique case (ctrl_transfer_target_mux_sel)
-          JT_JAL:  jump_target = pc_id_i + imm_uj_type;
-          JT_COND: jump_target = pc_id_i + imm_sb_type;
-
-          // JALR: Cannot forward RS1, since the path is too long
-          JT_JALR: jump_target = regfile_data_ra_id[0] + imm_i_type;
-          default: jump_target = regfile_data_ra_id[0] + imm_i_type;
-        endcase
-      end
+        // JALR: Cannot forward RS1, since the path is too long
+        JT_JALR: jump_target = regfile_data_ra_id[0] + imm_i_type;
+        default: jump_target = regfile_data_ra_id[0] + imm_i_type;
+      endcase
     end
   endgenerate
 
@@ -684,28 +671,15 @@ module cv32e40px_id_stage
   end
 
   generate
-    if (X_DUALREAD == 0) begin : no_dualread_fw_a
-      // Operand a forwarding mux
-      always_comb begin : operand_a_fw_mux
-        case (operand_a_fw_mux_sel)
-          SEL_FW_EX:   operand_a_fw_id = regfile_alu_wdata_fw_i;
-          SEL_FW_WB:   operand_a_fw_id = regfile_wdata_wb_i;
-          SEL_REGFILE: operand_a_fw_id = regfile_data_ra_id;
-          default:     operand_a_fw_id = regfile_data_ra_id;
-        endcase
-        ;  // case (operand_a_fw_mux_sel)
-      end
-    end else begin : dualread_fw_a
-      // Operand a forwarding mux
-      always_comb begin : operand_a_fw_mux
-        case (operand_a_fw_mux_sel)
-          SEL_FW_EX:   operand_a_fw_id = regfile_alu_wdata_fw_i;
-          SEL_FW_WB:   operand_a_fw_id = regfile_wdata_wb_i;
-          SEL_REGFILE: operand_a_fw_id = regfile_data_ra_id[0];
-          default:     operand_a_fw_id = regfile_data_ra_id[0];
-        endcase
-        ;  // case (operand_a_fw_mux_sel)
-      end
+    // Operand a forwarding mux
+    always_comb begin : operand_a_fw_mux
+      case (operand_a_fw_mux_sel)
+        SEL_FW_EX:   operand_a_fw_id = regfile_alu_wdata_fw_i;
+        SEL_FW_WB:   operand_a_fw_id = regfile_wdata_wb_i;
+        SEL_REGFILE: operand_a_fw_id = regfile_data_ra_id[0];
+        default:     operand_a_fw_id = regfile_data_ra_id[0];
+      endcase
+      ;  // case (operand_a_fw_mux_sel)
     end
   endgenerate
 

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -1037,40 +1037,44 @@ module cv32e40px_id_stage
   // |_| \_\_____\____|___|____/ |_| |_____|_| \_\____/  //
   //                                                     //
   /////////////////////////////////////////////////////////
+  
+      cv32e40px_register_file #(
+        .ADDR_WIDTH(6),
+        .DATA_WIDTH(32),
+        .FPU       (FPU),
+        .ZFINX     (ZFINX),
+        .COREV_X_IF(COREV_X_IF),
+        .X_DUALREAD(X_DUALREAD)
+      ) register_file_i (
+        .clk  (clk),
+        .rst_n(rst_n),
 
-  cv32e40px_register_file #(
-      .ADDR_WIDTH(6),
-      .DATA_WIDTH(32),
-      .FPU       (FPU),
-      .ZFINX     (ZFINX)
-  ) register_file_i (
-      .clk  (clk),
-      .rst_n(rst_n),
+        .scan_cg_en_i(scan_cg_en_i),
 
-      .scan_cg_en_i(scan_cg_en_i),
+        .dualread_i(x_issue_resp_i.dualread),
 
-      // Read port a
-      .raddr_a_i(regfile_addr_ra_id),
-      .rdata_a_o(regfile_data_ra_id[0]),
+        // Read port a
+        .raddr_a_i(regfile_addr_ra_id),
+        .rdata_a_o(regfile_data_ra_id),
 
-      // Read port b
-      .raddr_b_i(regfile_addr_rb_id),
-      .rdata_b_o(regfile_data_rb_id[0]),
+        // Read port b
+        .raddr_b_i(regfile_addr_rb_id),
+        .rdata_b_o(regfile_data_rb_id),
 
-      // Read port c
-      .raddr_c_i(regfile_addr_rc_id),
-      .rdata_c_o(regfile_data_rc_id[0]),
+        // Read port c
+        .raddr_c_i(regfile_addr_rc_id),
+        .rdata_c_o(regfile_data_rc_id),
 
-      // Write port a
-      .waddr_a_i(regfile_waddr_wb_i),
-      .wdata_a_i(regfile_wdata_wb_i),
-      .we_a_i   (regfile_we_wb_i),
+        // Write port a
+        .waddr_a_i(regfile_waddr_wb_i),
+        .wdata_a_i(regfile_wdata_wb_i),
+        .we_a_i   (regfile_we_wb_i),
 
-      // Write port b
-      .waddr_b_i(regfile_alu_waddr_fw_i),
-      .wdata_b_i(regfile_alu_wdata_fw_i),
-      .we_b_i   (regfile_alu_we_fw_i)
-  );
+        // Write port b
+        .waddr_b_i(regfile_alu_waddr_fw_i),
+        .wdata_b_i(regfile_alu_wdata_fw_i),
+        .we_b_i   (regfile_alu_we_fw_i)
+      );
 
   logic [1:0] x_mem_data_type_id;
 

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -440,8 +440,8 @@ module cv32e40px_id_stage
   logic [2:0][4:0] x_rs_addr;
   logic x_mem_data_req;
   logic x_mem_valid;
-  logic [2:0] x_ex_fwd;
-  logic [2:0] x_wb_fwd;
+  logic [RF_READ_PORTS-1:0] x_ex_fwd;
+  logic [RF_READ_PORTS-1:0] x_wb_fwd;
 
   // Register Write Control
   logic regfile_we_id;
@@ -1101,6 +1101,7 @@ module cv32e40px_id_stage
           .x_issue_valid_o         (x_issue_valid_o),
           .x_issue_ready_i         (x_issue_ready_i),
           .x_issue_resp_writeback_i(x_issue_resp_i.writeback),
+          .x_issue_resp_dualread_i(x_issue_resp_i.dualread),
           .x_issue_resp_accept_i   (x_issue_resp_i.accept),
           .x_issue_resp_loadstore_i(x_issue_resp_i.loadstore),
           .x_issue_req_rs_valid_o  (x_issue_req_o.rs_valid),
@@ -1192,14 +1193,15 @@ module cv32e40px_id_stage
             end else begin
               x_issue_req_o.rs[i+3*j] = regfile_data_rc_id[j];
             end
-            if (x_ex_fwd[i]) begin
+            if (x_ex_fwd[i+3*j]) begin
               x_issue_req_o.rs[i+3*j] = result_fw_to_x_i;
-            end else if (x_wb_fwd[i]) begin
+            end else if (x_wb_fwd[i+3*j]) begin
               x_issue_req_o.rs[i+3*j] = regfile_wdata_wb_i;
             end
           end
         end
       end
+      
       // LSU signal assignment/MUX
       always_comb begin
         x_mem_data_type_id = 2'b00;

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -1101,7 +1101,7 @@ module cv32e40px_id_stage
           .x_issue_valid_o         (x_issue_valid_o),
           .x_issue_ready_i         (x_issue_ready_i),
           .x_issue_resp_writeback_i(x_issue_resp_i.writeback),
-          .x_issue_resp_dualread_i(x_issue_resp_i.dualread),
+          .x_issue_resp_dualread_i (x_issue_resp_i.dualread),
           .x_issue_resp_accept_i   (x_issue_resp_i.accept),
           .x_issue_resp_loadstore_i(x_issue_resp_i.loadstore),
           .x_issue_req_rs_valid_o  (x_issue_req_o.rs_valid),
@@ -1201,7 +1201,7 @@ module cv32e40px_id_stage
           end
         end
       end
-      
+
       // LSU signal assignment/MUX
       always_comb begin
         x_mem_data_type_id = 2'b00;

--- a/rtl/cv32e40px_id_stage.sv
+++ b/rtl/cv32e40px_id_stage.sv
@@ -1182,19 +1182,21 @@ module cv32e40px_id_stage
       assign x_mem_valid = x_mem_valid_i;
 
       // xif integer souce operand selection
-      for (genvar i = 0; i < 3; i++) begin : xif_operand_assignment
-        always_comb begin
-          if (i == 0) begin
-            x_issue_req_o.rs[i] = regfile_data_ra_id[0];
-          end else if (i == 1) begin
-            x_issue_req_o.rs[i] = regfile_data_rb_id[0];
-          end else begin
-            x_issue_req_o.rs[i] = regfile_data_rc_id[0];
-          end
-          if (x_ex_fwd[i]) begin
-            x_issue_req_o.rs[i] = result_fw_to_x_i;
-          end else if (x_wb_fwd[i]) begin
-            x_issue_req_o.rs[i] = regfile_wdata_wb_i;
+      for (genvar j = 0; j < REGFILE_NUM_READ_PORTS; j++) begin : xif_operand_assignment_dualread
+        for (genvar i = 0; i < 3; i++) begin : xif_operand_assignment
+          always_comb begin
+            if (i == 0) begin
+              x_issue_req_o.rs[i + 3 * j] = regfile_data_ra_id[j];
+            end else if (i == 1) begin
+              x_issue_req_o.rs[i + 3 * j] = regfile_data_rb_id[j];
+            end else begin
+              x_issue_req_o.rs[i + 3 * j] = regfile_data_rc_id[j];
+            end
+            if (x_ex_fwd[i]) begin
+              x_issue_req_o.rs[i] = result_fw_to_x_i;
+            end else if (x_wb_fwd[i]) begin
+              x_issue_req_o.rs[i] = regfile_wdata_wb_i;
+            end
           end
         end
       end

--- a/rtl/cv32e40px_register_file_ff.sv
+++ b/rtl/cv32e40px_register_file_ff.sv
@@ -41,7 +41,7 @@ module cv32e40px_register_file #(
 
     input logic scan_cg_en_i,
 
-    input logic dualread_i,
+    input logic [2:0] dualread_i,
 
     //Read port R1
     input logic [ADDR_WIDTH-1:0] raddr_a_i,
@@ -94,21 +94,15 @@ module cv32e40px_register_file #(
     if (COREV_X_IF != 0) begin
       if (X_DUALREAD) begin
         always_comb begin
-          if (dualread_i) begin
             rdata_a_o[0] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
             rdata_b_o[0] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
             rdata_c_o[0] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
-            rdata_a_o[1] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0] | 5'b00001] : mem[raddr_a_i[4:0] | 5'b00001];
-            rdata_b_o[1] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0] | 5'b00001] : mem[raddr_b_i[4:0] | 5'b00001];
-            rdata_c_o[1] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0] | 5'b00001] : mem[raddr_c_i[4:0] | 5'b00001];
-          end else begin
-            rdata_a_o[0] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
-            rdata_b_o[0] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
-            rdata_c_o[0] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
-            rdata_b_o[1] = '0;
-            rdata_a_o[1] = '0;
-            rdata_c_o[1] = '0;
-          end
+            if (dualread_i[0] == 1) rdata_a_o[1] = raddr_a_i[5] ? (mem_fp[{raddr_a_i[4:1], raddr_a_i[0] | 1'b1}]) : (mem[{raddr_a_i[4:1], raddr_a_i[0] | 1'b1}]);
+            else rdata_a_o[1] = '0;
+            if (dualread_i[1] == 1) rdata_b_o[1] = raddr_b_i[5] ? (mem_fp[{raddr_b_i[4:1], raddr_b_i[0] | 1'b1}]) : (mem[{raddr_b_i[4:1], raddr_b_i[0] | 1'b1}]);
+            else rdata_b_o[1] = '0;
+            if (dualread_i[2] == 1) rdata_c_o[1] = raddr_c_i[5] ? (mem_fp[{raddr_c_i[4:1], raddr_c_i[0] | 1'b1}]) : (mem[{raddr_c_i[4:1], raddr_c_i[0] | 1'b1}]);
+            else rdata_c_o[1] = '0;
         end
       end else begin
         assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];

--- a/rtl/cv32e40px_register_file_ff.sv
+++ b/rtl/cv32e40px_register_file_ff.sv
@@ -44,15 +44,15 @@ module cv32e40px_register_file #(
     input logic dualread_i,
 
     //Read port R1
-    input  logic [ADDR_WIDTH-1:0] raddr_a_i,
+    input logic [ADDR_WIDTH-1:0] raddr_a_i,
     output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_a_o,
 
     //Read port R2
-    input  logic [ADDR_WIDTH-1:0] raddr_b_i,
+    input logic [ADDR_WIDTH-1:0] raddr_b_i,
     output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_b_o,
 
     //Read port R3
-    input  logic [ADDR_WIDTH-1:0] raddr_c_i,
+    input logic [ADDR_WIDTH-1:0] raddr_c_i,
     output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_c_o,
 
     // Write port W1
@@ -126,8 +126,8 @@ module cv32e40px_register_file #(
   //-----------------------------------------------------------------------------
 
   // Mask top bit of write address to disable fp regfile
-  assign waddr_a   = waddr_a_i;
-  assign waddr_b   = waddr_b_i;
+  assign waddr_a = waddr_a_i;
+  assign waddr_b = waddr_b_i;
 
   genvar gidx;
   generate

--- a/rtl/cv32e40px_register_file_ff.sv
+++ b/rtl/cv32e40px_register_file_ff.sv
@@ -31,7 +31,9 @@ module cv32e40px_register_file #(
     parameter ADDR_WIDTH = 5,
     parameter DATA_WIDTH = 32,
     parameter FPU        = 0,
-    parameter ZFINX      = 0
+    parameter ZFINX      = 0,
+    parameter COREV_X_IF = 0,
+    parameter X_DUALREAD = 0
 ) (
     // Clock and Reset
     input logic clk,
@@ -39,17 +41,19 @@ module cv32e40px_register_file #(
 
     input logic scan_cg_en_i,
 
+    input logic dualread_i,
+
     //Read port R1
     input  logic [ADDR_WIDTH-1:0] raddr_a_i,
-    output logic [DATA_WIDTH-1:0] rdata_a_o,
+    output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_a_o,
 
     //Read port R2
     input  logic [ADDR_WIDTH-1:0] raddr_b_i,
-    output logic [DATA_WIDTH-1:0] rdata_b_o,
+    output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_b_o,
 
     //Read port R3
     input  logic [ADDR_WIDTH-1:0] raddr_c_i,
-    output logic [DATA_WIDTH-1:0] rdata_c_o,
+    output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_c_o,
 
     // Write port W1
     input logic [ADDR_WIDTH-1:0] waddr_a_i,
@@ -86,10 +90,37 @@ module cv32e40px_register_file #(
   //-----------------------------------------------------------------------------
   //-- READ : Read address decoder RAD
   //-----------------------------------------------------------------------------
-  assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
-  assign rdata_b_o = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
-  assign rdata_c_o = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
-
+  generate
+    if (COREV_X_IF != 0) begin
+      if (X_DUALREAD) begin
+        always_comb begin
+          if (dualread_i) begin
+            rdata_a_o[0] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+            rdata_b_o[0] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+            rdata_c_o[0] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+            rdata_a_o[1] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0] | 5'b00001] : mem[raddr_a_i[4:0] | 5'b00001];
+            rdata_b_o[1] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0] | 5'b00001] : mem[raddr_b_i[4:0] | 5'b00001];
+            rdata_c_o[1] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0] | 5'b00001] : mem[raddr_c_i[4:0] | 5'b00001];
+          end else begin
+            rdata_a_o[0] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+            rdata_b_o[0] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+            rdata_c_o[0] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+            rdata_b_o[1] = '0;
+            rdata_a_o[1] = '0;
+            rdata_c_o[1] = '0;
+          end
+        end
+      end else begin
+        assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+        assign rdata_b_o = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+        assign rdata_c_o = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+      end
+    end else begin
+      assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+      assign rdata_b_o = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+      assign rdata_c_o = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+    end
+  endgenerate
   //-----------------------------------------------------------------------------
   //-- WRITE : Write Address Decoder (WAD), combinatorial process
   //-----------------------------------------------------------------------------

--- a/rtl/cv32e40px_register_file_latch.sv
+++ b/rtl/cv32e40px_register_file_latch.sv
@@ -33,7 +33,9 @@ module cv32e40px_register_file #(
     parameter ADDR_WIDTH = 5,
     parameter DATA_WIDTH = 32,
     parameter FPU        = 0,
-    parameter ZFINX      = 0
+    parameter ZFINX      = 0,
+    parameter COREV_X_IF = 0,
+    parameter X_DUALREAD = 0
 ) (
     // Clock and Reset
     input logic clk,
@@ -41,17 +43,19 @@ module cv32e40px_register_file #(
 
     input logic scan_cg_en_i,
 
+    input logic dualread_i,
+
     //Read port R1
     input  logic [ADDR_WIDTH-1:0] raddr_a_i,
-    output logic [DATA_WIDTH-1:0] rdata_a_o,
+    output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_a_o,
 
     //Read port R2
     input  logic [ADDR_WIDTH-1:0] raddr_b_i,
-    output logic [DATA_WIDTH-1:0] rdata_b_o,
+    output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_b_o,
 
     //Read port R3
     input  logic [ADDR_WIDTH-1:0] raddr_c_i,
-    output logic [DATA_WIDTH-1:0] rdata_c_o,
+    output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_c_o,
 
     // Write port W1
     input logic [ADDR_WIDTH-1:0] waddr_a_i,
@@ -98,10 +102,37 @@ module cv32e40px_register_file #(
   //-----------------------------------------------------------------------------
   //-- READ : Read address decoder RAD
   //-----------------------------------------------------------------------------
-  assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
-  assign rdata_b_o = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
-  assign rdata_c_o = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
-
+  generate
+    if (COREV_X_IF != 0) begin
+      if (X_DUALREAD) begin
+        always_comb begin
+          if (dualread_i) begin
+            rdata_a_o[0] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+            rdata_b_o[0] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+            rdata_c_o[0] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+            rdata_a_o[1] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0] | 5'b00001] : mem[raddr_a_i[4:0] | 5'b00001];
+            rdata_b_o[1] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0] | 5'b00001] : mem[raddr_b_i[4:0] | 5'b00001];
+            rdata_c_o[1] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0] | 5'b00001] : mem[raddr_c_i[4:0] | 5'b00001];
+          end else begin
+            rdata_a_o[0] = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+            rdata_b_o[0] = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+            rdata_c_o[0] = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+            rdata_b_o[1] = '0;
+            rdata_a_o[1] = '0;
+            rdata_c_o[1] = '0;
+          end
+        end
+      end else begin
+        assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+        assign rdata_b_o = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+        assign rdata_c_o = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+      end
+    end else begin
+      assign rdata_a_o = raddr_a_i[5] ? mem_fp[raddr_a_i[4:0]] : mem[raddr_a_i[4:0]];
+      assign rdata_b_o = raddr_b_i[5] ? mem_fp[raddr_b_i[4:0]] : mem[raddr_b_i[4:0]];
+      assign rdata_c_o = raddr_c_i[5] ? mem_fp[raddr_c_i[4:0]] : mem[raddr_c_i[4:0]];
+    end
+  endgenerate
   //-----------------------------------------------------------------------------
   // WRITE : SAMPLE INPUT DATA
   //---------------------------------------------------------------------------

--- a/rtl/cv32e40px_register_file_latch.sv
+++ b/rtl/cv32e40px_register_file_latch.sv
@@ -46,15 +46,15 @@ module cv32e40px_register_file #(
     input logic dualread_i,
 
     //Read port R1
-    input  logic [ADDR_WIDTH-1:0] raddr_a_i,
+    input logic [ADDR_WIDTH-1:0] raddr_a_i,
     output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_a_o,
 
     //Read port R2
-    input  logic [ADDR_WIDTH-1:0] raddr_b_i,
+    input logic [ADDR_WIDTH-1:0] raddr_b_i,
     output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_b_o,
 
     //Read port R3
-    input  logic [ADDR_WIDTH-1:0] raddr_c_i,
+    input logic [ADDR_WIDTH-1:0] raddr_c_i,
     output logic [X_DUALREAD:0][DATA_WIDTH-1:0] rdata_c_o,
 
     // Write port W1

--- a/rtl/cv32e40px_x_disp.sv
+++ b/rtl/cv32e40px_x_disp.sv
@@ -33,7 +33,8 @@ module cv32e40px_x_disp
     input  logic                     x_issue_ready_i,
     input  logic                     x_issue_resp_accept_i,
     input  logic                     x_issue_resp_writeback_i,
-    input  logic                     x_issue_resp_dualread_i,
+
+    input  logic [              2:0] x_issue_resp_dualread_i,
     input  logic                     x_issue_resp_loadstore_i,  // unused
     output logic [RF_READ_PORTS-1:0] x_issue_req_rs_valid_o,
     output logic [              3:0] x_issue_req_id_o,
@@ -119,11 +120,11 @@ module cv32e40px_x_disp
       assign x_issue_req_rs_valid_o[2] = (~scoreboard_q[x_rs_addr_i[2]] | x_ex_fwd_o[2] | x_wb_fwd_o[2])
                                          & ~(x_rs_addr_i[2] == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[2] == waddr_wb_i & ~ex_valid_i);
       assign x_issue_req_rs_valid_o[3] = (~scoreboard_q[x_rs_addr_i[0] | 5'b00001] | x_ex_fwd_o[3] | x_wb_fwd_o[3])
-                                         & ~(x_rs_addr_i[0] | 5'b00001 == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[0] | 5'b00001 == waddr_wb_i & ~ex_valid_i);
+                                         & ~((x_rs_addr_i[0] | 5'b00001) == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~((x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & ~ex_valid_i);
       assign x_issue_req_rs_valid_o[4] = (~scoreboard_q[x_rs_addr_i[1] | 5'b00001] | x_ex_fwd_o[4] | x_wb_fwd_o[4])
-                                         & ~(x_rs_addr_i[1] | 5'b00001 == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[1] | 5'b00001 == waddr_wb_i & ~ex_valid_i);
+                                         & ~((x_rs_addr_i[1] | 5'b00001) == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~((x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & ~ex_valid_i);
       assign x_issue_req_rs_valid_o[5] = (~scoreboard_q[x_rs_addr_i[2] | 5'b00001] | x_ex_fwd_o[5] | x_wb_fwd_o[5])
-                                         & ~(x_rs_addr_i[2] | 5'b00001 == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[2] | 5'b00001 == waddr_wb_i & ~ex_valid_i);
+                                         & ~((x_rs_addr_i[2] | 5'b00001) == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~((x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & ~ex_valid_i);
       assign x_issue_req_ecs_valid = 1'b1;  // extension context status is not implemented in cv32e40px
     end else begin
       assign x_issue_req_rs_valid_o[0] = (~scoreboard_q[x_rs_addr_i[0]] | x_ex_fwd_o[0] | x_wb_fwd_o[0])
@@ -171,21 +172,21 @@ module cv32e40px_x_disp
       assign x_ex_fwd_o[0] = x_rs_addr_i[0] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[1] = x_rs_addr_i[1] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[2] = x_rs_addr_i[2] == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i;
-      assign x_ex_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i;
-      assign x_ex_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i;
+      assign x_ex_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i[0];
+      assign x_ex_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i[1];
+      assign x_ex_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i[2];
       assign x_wb_fwd_o[0] = x_rs_addr_i[0] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[1] = x_rs_addr_i[1] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[2] = x_rs_addr_i[2] == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i;
-      assign x_wb_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i;
-      assign x_wb_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i;
+      assign x_wb_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i[0];
+      assign x_wb_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i[1];
+      assign x_wb_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i[2];
       assign dep = ~x_illegal_insn_o & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
                                   |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
                                   |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2]))
-                                  |     (((regs_used_i[0] & x_issue_resp_dualread_i) & scoreboard_q[x_rs_addr_i[0] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[0] | 5'b00001))) & x_issue_resp_dualread_i)
-                                  |     (((regs_used_i[1] & x_issue_resp_dualread_i) & scoreboard_q[x_rs_addr_i[1] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[1] | 5'b00001))) & x_issue_resp_dualread_i)
-                                  |     (((regs_used_i[2] & x_issue_resp_dualread_i) & scoreboard_q[x_rs_addr_i[2] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[2] | 5'b00001))) & x_issue_resp_dualread_i));
+                                  |     (((regs_used_i[0] & x_issue_resp_dualread_i[0]) & scoreboard_q[x_rs_addr_i[0] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[0] | 5'b00001))) & x_issue_resp_dualread_i[0])
+                                  |     (((regs_used_i[1] & x_issue_resp_dualread_i[1]) & scoreboard_q[x_rs_addr_i[1] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[1] | 5'b00001))) & x_issue_resp_dualread_i[1])
+                                  |     (((regs_used_i[2] & x_issue_resp_dualread_i[2]) & scoreboard_q[x_rs_addr_i[2] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[2] | 5'b00001))) & x_issue_resp_dualread_i[2]));
     end else begin
       assign x_ex_fwd_o[0] = x_rs_addr_i[0] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[1] = x_rs_addr_i[1] == waddr_ex_i & we_ex_i & ex_valid_i;

--- a/rtl/cv32e40px_x_disp.sv
+++ b/rtl/cv32e40px_x_disp.sv
@@ -33,6 +33,7 @@ module cv32e40px_x_disp
     input  logic                     x_issue_ready_i,
     input  logic                     x_issue_resp_accept_i,
     input  logic                     x_issue_resp_writeback_i,
+    input  logic                     x_issue_resp_dualread_i,
     input  logic                     x_issue_resp_loadstore_i,  // unused
     output logic [RF_READ_PORTS-1:0] x_issue_req_rs_valid_o,
     output logic [              3:0] x_issue_req_id_o,
@@ -75,9 +76,9 @@ module cv32e40px_x_disp
     input  logic [              2:0]      regs_used_i,
     input  logic                          branch_or_jump_i,
     input  logic                          instr_valid_i,
-    input  logic [RF_READ_PORTS-1:0][4:0] x_rs_addr_i,
+    input  logic [2:0][4:0] x_rs_addr_i,
     output logic [RF_READ_PORTS-1:0]      x_ex_fwd_o,
-    output logic [              2:0]      x_wb_fwd_o,
+    output logic [RF_READ_PORTS-1:0]      x_wb_fwd_o,
 
     // memory request core-internal status signals
     output logic x_mem_data_req_o,
@@ -117,12 +118,12 @@ module cv32e40px_x_disp
                                          & ~(x_rs_addr_i[1] == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[1] == waddr_wb_i & ~ex_valid_i);
       assign x_issue_req_rs_valid_o[2] = (~scoreboard_q[x_rs_addr_i[2]] | x_ex_fwd_o[2] | x_wb_fwd_o[2])
                                          & ~(x_rs_addr_i[2] == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[2] == waddr_wb_i & ~ex_valid_i);
-      assign x_issue_req_rs_valid_o[3] = (~scoreboard_q[x_rs_addr_i[3]] | x_ex_fwd_o[3] | x_wb_fwd_o[3])
-                                         & ~(x_rs_addr_i[3] == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[3] == waddr_wb_i & ~ex_valid_i);
-      assign x_issue_req_rs_valid_o[4] = (~scoreboard_q[x_rs_addr_i[4]] | x_ex_fwd_o[4] | x_wb_fwd_o[4])
-                                         & ~(x_rs_addr_i[4] == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[4] == waddr_wb_i & ~ex_valid_i);
-      assign x_issue_req_rs_valid_o[5] = (~scoreboard_q[x_rs_addr_i[5]] | x_ex_fwd_o[5] | x_wb_fwd_o[5])
-                                         & ~(x_rs_addr_i[5] == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[5] == waddr_wb_i & ~ex_valid_i);
+      assign x_issue_req_rs_valid_o[3] = (~scoreboard_q[x_rs_addr_i[0] | 5'b00001] | x_ex_fwd_o[3] | x_wb_fwd_o[3])
+                                         & ~(x_rs_addr_i[0] | 5'b00001 == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[0] | 5'b00001 == waddr_wb_i & ~ex_valid_i);
+      assign x_issue_req_rs_valid_o[4] = (~scoreboard_q[x_rs_addr_i[1] | 5'b00001] | x_ex_fwd_o[4] | x_wb_fwd_o[4])
+                                         & ~(x_rs_addr_i[1] | 5'b00001 == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[1] | 5'b00001 == waddr_wb_i & ~ex_valid_i);
+      assign x_issue_req_rs_valid_o[5] = (~scoreboard_q[x_rs_addr_i[2] | 5'b00001] | x_ex_fwd_o[5] | x_wb_fwd_o[5])
+                                         & ~(x_rs_addr_i[2] | 5'b00001 == mem_instr_waddr_ex_i & mem_instr_we_ex_i) & ~(x_rs_addr_i[2] | 5'b00001 == waddr_wb_i & ~ex_valid_i);
       assign x_issue_req_ecs_valid = 1'b1;  // extension context status is not implemented in cv32e40px
     end else begin
       assign x_issue_req_rs_valid_o[0] = (~scoreboard_q[x_rs_addr_i[0]] | x_ex_fwd_o[0] | x_wb_fwd_o[0])
@@ -157,9 +158,7 @@ module cv32e40px_x_disp
 
   // core stall signal
   assign x_stall_o = dep | outstanding_mem | x_if_not_ready | x_if_memory_instr | illegal_forwarding_prevention;
-  assign dep = ~x_illegal_insn_o & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
-                                  | (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
-                                  | (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2])));
+  
   assign outstanding_mem = data_req_dec_i & (mem_counter_q != '0);
   assign x_if_memory_instr = x_mem_data_req_o & ~(x_issue_valid_o & x_issue_ready_i);
   assign x_if_not_ready = x_issue_valid_o & ~x_issue_ready_i;
@@ -181,6 +180,12 @@ module cv32e40px_x_disp
       assign x_wb_fwd_o[3] = x_rs_addr_i[3] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[4] = x_rs_addr_i[4] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[5] = x_rs_addr_i[5] == waddr_wb_i & we_wb_i & ex_valid_i;
+      assign dep = ~x_illegal_insn_o & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
+                                  |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
+                                  |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2]))
+                                  |     (((regs_used_i[0] & x_issue_resp_dualread_i) & scoreboard_q[x_rs_addr_i[0] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[0] | 5'b00001))) & x_issue_resp_dualread_i)
+                                  |     (((regs_used_i[1] & x_issue_resp_dualread_i) & scoreboard_q[x_rs_addr_i[1] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[1] | 5'b00001))) & x_issue_resp_dualread_i)
+                                  |     (((regs_used_i[2] & x_issue_resp_dualread_i) & scoreboard_q[x_rs_addr_i[2] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[2] | 5'b00001))) & x_issue_resp_dualread_i));
     end else begin
       assign x_ex_fwd_o[0] = x_rs_addr_i[0] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[1] = x_rs_addr_i[1] == waddr_ex_i & we_ex_i & ex_valid_i;
@@ -188,6 +193,9 @@ module cv32e40px_x_disp
       assign x_wb_fwd_o[0] = x_rs_addr_i[0] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[1] = x_rs_addr_i[1] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[2] = x_rs_addr_i[2] == waddr_wb_i & we_wb_i & ex_valid_i;
+      assign dep = ~x_illegal_insn_o & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
+                                  |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
+                                  |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2])));
     end
   endgenerate
 

--- a/rtl/cv32e40px_x_disp.sv
+++ b/rtl/cv32e40px_x_disp.sv
@@ -171,15 +171,15 @@ module cv32e40px_x_disp
       assign x_ex_fwd_o[0] = x_rs_addr_i[0] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[1] = x_rs_addr_i[1] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[2] = x_rs_addr_i[2] == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[3] = x_rs_addr_i[3] == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[4] = x_rs_addr_i[4] == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[5] = x_rs_addr_i[5] == waddr_ex_i & we_ex_i & ex_valid_i;
+      assign x_ex_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i;
+      assign x_ex_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i;
+      assign x_ex_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_wb_fwd_o[0] = x_rs_addr_i[0] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[1] = x_rs_addr_i[1] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[2] = x_rs_addr_i[2] == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[3] = x_rs_addr_i[3] == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[4] = x_rs_addr_i[4] == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[5] = x_rs_addr_i[5] == waddr_wb_i & we_wb_i & ex_valid_i;
+      assign x_wb_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i;
+      assign x_wb_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i;
+      assign x_wb_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i;
       assign dep = ~x_illegal_insn_o & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
                                   |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
                                   |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2]))

--- a/rtl/cv32e40px_x_disp.sv
+++ b/rtl/cv32e40px_x_disp.sv
@@ -171,15 +171,15 @@ module cv32e40px_x_disp
       assign x_ex_fwd_o[0] = x_rs_addr_i[0] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[1] = x_rs_addr_i[1] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[2] = x_rs_addr_i[2] == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i;
-      assign x_ex_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i;
+      assign x_ex_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i;
+      assign x_ex_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i;
+      assign x_ex_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_ex_i & we_ex_i & ex_valid_i & x_issue_resp_dualread_i;
       assign x_wb_fwd_o[0] = x_rs_addr_i[0] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[1] = x_rs_addr_i[1] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[2] = x_rs_addr_i[2] == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign x_wb_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i;
+      assign x_wb_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i;
+      assign x_wb_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i;
+      assign x_wb_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i;
       assign dep = ~x_illegal_insn_o & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
                                   |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
                                   |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2]))

--- a/rtl/cv32e40px_x_disp.sv
+++ b/rtl/cv32e40px_x_disp.sv
@@ -76,7 +76,7 @@ module cv32e40px_x_disp
     input  logic [              2:0]      regs_used_i,
     input  logic                          branch_or_jump_i,
     input  logic                          instr_valid_i,
-    input  logic [2:0][4:0] x_rs_addr_i,
+    input  logic [              2:0][4:0] x_rs_addr_i,
     output logic [RF_READ_PORTS-1:0]      x_ex_fwd_o,
     output logic [RF_READ_PORTS-1:0]      x_wb_fwd_o,
 
@@ -158,7 +158,7 @@ module cv32e40px_x_disp
 
   // core stall signal
   assign x_stall_o = dep | outstanding_mem | x_if_not_ready | x_if_memory_instr | illegal_forwarding_prevention;
-  
+
   assign outstanding_mem = data_req_dec_i & (mem_counter_q != '0);
   assign x_if_memory_instr = x_mem_data_req_o & ~(x_issue_valid_o & x_issue_ready_i);
   assign x_if_not_ready = x_issue_valid_o & ~x_issue_ready_i;

--- a/rtl/include/cv32e40px_core_v_xif_pkg.sv
+++ b/rtl/include/cv32e40px_core_v_xif_pkg.sv
@@ -15,6 +15,7 @@ package cv32e40px_core_v_xif_pkg;
 
   // cv-x-if parameters
   parameter int X_NUM_RS = 3;
+  parameter int X_DUALREAD = 1;
   parameter int X_ID_WIDTH = 4;
   parameter int X_MEM_WIDTH = 32;
   parameter int X_RFR_WIDTH = 32;
@@ -39,7 +40,7 @@ package cv32e40px_core_v_xif_pkg;
     logic [31:0] instr;  // Offloaded instruction
     logic [1:0] mode;  // Privilege level
     logic [X_ID_WIDTH-1:0] id;  // Identification of the offloaded instruction
-    logic [X_NUM_RS  -1:0][X_RFR_WIDTH-1:0] rs;        // Register file source operands for the offloaded instruction
+    logic [(X_NUM_RS + X_NUM_RS * 2 * X_DUALREAD)  -1:0][X_RFR_WIDTH-1:0] rs;        // Register file source operands for the offloaded instruction
     logic [X_NUM_RS  -1:0] rs_valid;  // Validity of the register file source operand(s)
     logic [5:0] ecs;  // Extension Context Status ({mstatus.xs, mstatus.fs, mstatus.vs})
     logic ecs_valid;  // Validity of the Extension Context Status

--- a/rtl/include/cv32e40px_core_v_xif_pkg.sv
+++ b/rtl/include/cv32e40px_core_v_xif_pkg.sv
@@ -24,7 +24,8 @@ package cv32e40px_core_v_xif_pkg;
   parameter logic [1:0] X_ECS_XS = '0;
 
   localparam int XLEN = 32;
-  localparam int RF_READ_PORTS = X_DUALREAD ? 2 * X_NUM_RS : X_NUM_RS;
+  localparam int RF_READ_PORTS = (X_DUALREAD == 1) ? 2 * X_NUM_RS : X_NUM_RS;
+
 
   typedef struct packed {
     logic [15:0] instr;  // Offloaded compressed instruction

--- a/rtl/include/cv32e40px_core_v_xif_pkg.sv
+++ b/rtl/include/cv32e40px_core_v_xif_pkg.sv
@@ -24,6 +24,7 @@ package cv32e40px_core_v_xif_pkg;
   parameter logic [1:0] X_ECS_XS = '0;
 
   localparam int XLEN = 32;
+  localparam int RF_READ_PORTS = X_DUALREAD ? 2 * X_NUM_RS : X_NUM_RS;
 
   typedef struct packed {
     logic [15:0] instr;  // Offloaded compressed instruction
@@ -35,8 +36,6 @@ package cv32e40px_core_v_xif_pkg;
     logic [31:0] instr;  // Uncompressed instruction
     logic accept;  // Is the offloaded compressed instruction (id) accepted by the coprocessor?
   } x_compressed_resp_t;
-
-  localparam integer RF_READ_PORTS = X_DUALREAD ? 2 * X_NUM_RS : X_NUM_RS;
 
   typedef struct packed {
     logic [31:0] instr;  // Offloaded instruction

--- a/rtl/include/cv32e40px_core_v_xif_pkg.sv
+++ b/rtl/include/cv32e40px_core_v_xif_pkg.sv
@@ -36,12 +36,14 @@ package cv32e40px_core_v_xif_pkg;
     logic accept;  // Is the offloaded compressed instruction (id) accepted by the coprocessor?
   } x_compressed_resp_t;
 
+  localparam integer RF_READ_PORTS = X_DUALREAD ? 2 * X_NUM_RS : X_NUM_RS;
+
   typedef struct packed {
     logic [31:0] instr;  // Offloaded instruction
     logic [1:0] mode;  // Privilege level
     logic [X_ID_WIDTH-1:0] id;  // Identification of the offloaded instruction
-    logic [(X_NUM_RS + X_NUM_RS * 2 * X_DUALREAD)  -1:0][X_RFR_WIDTH-1:0] rs;        // Register file source operands for the offloaded instruction
-    logic [X_NUM_RS  -1:0] rs_valid;  // Validity of the register file source operand(s)
+    logic [RF_READ_PORTS-1:0][X_RFR_WIDTH-1:0] rs;        // Register file source operands for the offloaded instruction
+    logic [RF_READ_PORTS-1:0] rs_valid;  // Validity of the register file source operand(s)
     logic [5:0] ecs;  // Extension Context Status ({mstatus.xs, mstatus.fs, mstatus.vs})
     logic ecs_valid;  // Validity of the Extension Context Status
   } x_issue_req_t;

--- a/rtl/include/cv32e40px_core_v_xif_pkg.sv
+++ b/rtl/include/cv32e40px_core_v_xif_pkg.sv
@@ -15,7 +15,7 @@ package cv32e40px_core_v_xif_pkg;
 
   // cv-x-if parameters
   parameter int X_NUM_RS = 3;
-  parameter int X_DUALREAD = 1;
+  parameter int X_DUALREAD = 0; // 0: single read, 1: dual read
   parameter int X_ID_WIDTH = 4;
   parameter int X_MEM_WIDTH = 32;
   parameter int X_RFR_WIDTH = 32;


### PR DESCRIPTION
### Description

This PR adds to CV32E40PX the support for [dualread ](https://docs.openhwgroup.org/projects/openhw-group-core-v-xif/en/latest/x_ext.html#issue-interface:~:text=Support%20for%20dual%20read,supported%20for%20XLEN%20%3D%2032.) feature of core-v-xif. This feature permits to pass to a coprocessor up to 6 operands.

### Proposed solution

- The parameter `X_DUALREAD` is added to `rtl/include/cv32e40px_core_v_xif_pkg.sv`, when it is equal to 1 the dual read feature is enabled and all the parametric signals are instantiated with the correct size, indeed the RS operands to be passed to the xif are 6 and not 3
- As stated by the interface description "Dual read is supported for even-odd register pairs", so the addresses of the additional register operands are computed internally to the RF (both FF and LATCH register files modified) from the base register addresses by an `or` on the LSB
- Forwarding from execution and writeback stages to the xif is possible both for the base and the additional registers. The former is always computed, the latter only if a dual read request is issued by the coprocessor