### PR TITLE
x_disp: fix pipeline not stalling when it should

### DIFF
--- a/rtl/cv32e40px_x_disp.sv
+++ b/rtl/cv32e40px_x_disp.sv
@@ -184,12 +184,12 @@ module cv32e40px_x_disp
       assign x_wb_fwd_o[3] = (x_rs_addr_i[0] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i[0];
       assign x_wb_fwd_o[4] = (x_rs_addr_i[1] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i[1];
       assign x_wb_fwd_o[5] = (x_rs_addr_i[2] | 5'b00001) == waddr_wb_i & we_wb_i & ex_valid_i & x_issue_resp_dualread_i[2];
-      assign dep = ~x_illegal_insn_n & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
-                                  |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
-                                  |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2]))
-                                  |     (((regs_used_i[0] & x_issue_resp_dualread_i[0]) & scoreboard_q[x_rs_addr_i[0] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[0] | 5'b00001))) & x_issue_resp_dualread_i[0])
-                                  |     (((regs_used_i[1] & x_issue_resp_dualread_i[1]) & scoreboard_q[x_rs_addr_i[1] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[1] | 5'b00001))) & x_issue_resp_dualread_i[1])
-                                  |     (((regs_used_i[2] & x_issue_resp_dualread_i[2]) & scoreboard_q[x_rs_addr_i[2] | 5'b00001] & (x_result_rd_i != (x_rs_addr_i[2] | 5'b00001))) & x_issue_resp_dualread_i[2]));
+      assign dep = ~x_illegal_insn_n & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & scoreboard_d[x_rs_addr_i[0]])
+                                  |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & scoreboard_d[x_rs_addr_i[1]])
+                                  |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & scoreboard_d[x_rs_addr_i[2]])
+                                  |     ((regs_used_i[0] & x_issue_resp_dualread_i[0]) & scoreboard_q[x_rs_addr_i[0] | 5'b00001] & scoreboard_d[x_rs_addr_i[0] | 5'b00001])
+                                  |     ((regs_used_i[1] & x_issue_resp_dualread_i[1]) & scoreboard_q[x_rs_addr_i[1] | 5'b00001] & scoreboard_d[x_rs_addr_i[1] | 5'b00001])
+                                  |     ((regs_used_i[2] & x_issue_resp_dualread_i[2]) & scoreboard_q[x_rs_addr_i[2] | 5'b00001] & scoreboard_d[x_rs_addr_i[2] | 5'b00001]));
     end else begin : gen_fwd_no_dualread
       assign x_ex_fwd_o[0] = x_rs_addr_i[0] == waddr_ex_i & we_ex_i & ex_valid_i;
       assign x_ex_fwd_o[1] = x_rs_addr_i[1] == waddr_ex_i & we_ex_i & ex_valid_i;
@@ -197,9 +197,9 @@ module cv32e40px_x_disp
       assign x_wb_fwd_o[0] = x_rs_addr_i[0] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[1] = x_rs_addr_i[1] == waddr_wb_i & we_wb_i & ex_valid_i;
       assign x_wb_fwd_o[2] = x_rs_addr_i[2] == waddr_wb_i & we_wb_i & ex_valid_i;
-      assign dep = ~x_illegal_insn_n & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & (x_result_rd_i != x_rs_addr_i[0]))
-                                  |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & (x_result_rd_i != x_rs_addr_i[1]))
-                                  |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & (x_result_rd_i != x_rs_addr_i[2])));
+      assign dep = ~x_illegal_insn_n & ((regs_used_i[0] & scoreboard_q[x_rs_addr_i[0]] & scoreboard_d[x_rs_addr_i[0]])
+                                  |     (regs_used_i[1] & scoreboard_q[x_rs_addr_i[1]] & scoreboard_d[x_rs_addr_i[1]])
+                                  |     (regs_used_i[2] & scoreboard_q[x_rs_addr_i[2]] & scoreboard_d[x_rs_addr_i[2]]));
     end
   endgenerate
 


### PR DESCRIPTION
The `dep` signal is generated so that it stalls the pipeline when:
- An instruction uses a certain register (rs1, rs2, or rs3).
- This register is marked on the x_disp scoreboard as unavailable (i.e., the core is waiting for the coprocessor to write its value).
- The coprocessor is not writing the value of the register in this very moment (i.e., the register won't be marked as available next cycle).

However, the 3rd condition isn't currently written properly, and it simply checks the value of `x_result_rd_i`, without checking if it's valid (`x_result_valid_i = 1`) and actually being written (`x_result_we_i = 1`).

Specifically, if an X-IF coprocessor writes anything other than all zeros to `x_result_rd_i` at a time when this signal is meant to be ignored, an instruction that was being held in the pipeline waiting for this register may be released prematurely, before the register value is written.  This scenario may happen in the following circumstances:
- The output value at `x_result_rd_i` is indeterminate while `x_result_valid_i = 0`.  This is a valid approach and can simplify HW design (in general, in a valid-ready handshake, when valid=0 the value of all other signals is meant to be ignored).
- The output value at `x_result_rd_i` is meant to be ignored when `x_result_we_i = 0`.  I understand that this implementation is valid as well, as it allows simplifying the logic by simply making `x_result_rd_i` replicate the value of bits [11:7] of the incoming instruction, whether the instruction performs a register writeback or not (whether this happens is indicated in bit `x_result_we_i` rather than the value of `x_result_rd_i`).

This PR rewrites the condition to check scratchpad_d directly (i.e., the value scratchpad_q will have on the next clock cycle), which already happens to perform those two checks.  In other words, it checks whether the register has been marked as "write pending" AND if it will still be marked as "write pending" in the next clock cycle.

Fixes #10.